### PR TITLE
Fix typo in stream name

### DIFF
--- a/content-pack-nginx-graylog3.json
+++ b/content-pack-nginx-graylog3.json
@@ -1045,7 +1045,7 @@
         },
         "title": {
           "@type": "string",
-          "@value": "nginx HTTP 5XXXs"
+          "@value": "nginx HTTP 5XXs"
         },
         "stream_rules": [
           {


### PR DESCRIPTION
github added a linebreak at the end of the file outside of my control, hence that change included in the patch.